### PR TITLE
Handle a few more configuration options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -88,6 +88,15 @@ class consul_template::config (
     }
   }
 
+  # Set syslog param if specified
+  if $::consul_template::syslog_enabled {
+    concat::fragment { 'syslog':
+      target  => 'consul-template/config.json',
+      content => inline_template("syslog {\n  enabled = true\n  facility = \"${::consul_template::syslog_facility}\"\n}\n\n"),
+      order   => '11',
+    }
+  }
+
   file { [$consul_template::config_dir, "${consul_template::config_dir}/config"]:
     ensure  => 'directory',
     purge   => $purge,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,8 @@ class consul_template (
   $logrotate_files    = 4,
   $logrotate_on       = false,
   $logrotate_period   = 'daily',
+  $syslog_enabled     = false,
+  $syslog_facility    = 'DAEMON',
   $vault_enabled      = false,
   $vault_address      = '',
   $vault_token        = '',

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -10,6 +10,9 @@ define consul_template::watch (
   $template      = undef,
   $template_vars = {},
   $perms = '0644',
+  $command_timeout = '30s',
+  $backup = false,
+  $wait = undef
 ) {
   include consul_template
 
@@ -41,9 +44,15 @@ define consul_template::watch (
     $frag_name   = "${name}.ctmpl"
   }
 
+  if $wait != undef {
+    $fragment_wait = "  wait = \"${wait}\"\n"
+  } else {
+    $fragment_wait = ''
+  }
+
   concat::fragment { $frag_name:
     target  => 'consul-template/config.json',
-    content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n  perms = ${perms}\n}\n\n",
+    content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n  perms = ${perms}\n  backup = ${backup}\n  command_timeout = \"${command_timeout}\"\n${fragment_wait}}\n\n",
     order   => '20',
     notify  => Service['consul-template']
   }


### PR DESCRIPTION
Handle 'backup', 'command_timeout' and 'wait' options for watches and global syslog config.